### PR TITLE
Add binary greedy mesher GDExtension

### DIFF
--- a/mixed-voxels/extensions/binary_greedy_mesher/SConstruct
+++ b/mixed-voxels/extensions/binary_greedy_mesher/SConstruct
@@ -1,0 +1,14 @@
+import os
+
+# Attempt to use godot-cpp's build script if available
+if os.path.exists('../../godot-cpp/SConstruct'):
+    env = SConscript('../../godot-cpp/SConstruct', exports='env')
+else:
+    env = Environment()
+
+env.Append(CPPPATH=['src'])
+
+sources = Glob('src/*.cpp')
+lib_name = 'bin/libbinary_greedy_mesher'
+
+env.SharedLibrary(lib_name, sources)

--- a/mixed-voxels/extensions/binary_greedy_mesher/binary_greedy_mesher.gdextension
+++ b/mixed-voxels/extensions/binary_greedy_mesher/binary_greedy_mesher.gdextension
@@ -1,0 +1,6 @@
+[configuration]
+entry_symbol="binary_greedy_mesher_library_init"
+
+[libraries]
+linux.debug.x86_64="bin/libbinary_greedy_mesher.linux.template_debug.x86_64.so"
+linux.release.x86_64="bin/libbinary_greedy_mesher.linux.template_release.x86_64.so"

--- a/mixed-voxels/extensions/binary_greedy_mesher/src/binary_greedy_mesher.cpp
+++ b/mixed-voxels/extensions/binary_greedy_mesher/src/binary_greedy_mesher.cpp
@@ -1,0 +1,172 @@
+#include "binary_greedy_mesher.h"
+
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/packed_int32_array.hpp>
+#include <godot_cpp/variant/packed_vector3_array.hpp>
+#include <vector>
+
+using namespace godot;
+
+static inline bool voxel_at(const uint8_t *data, int x, int y, int z, const Vector3i &size) {
+    if (x < 0 || y < 0 || z < 0 || x >= size.x || y >= size.y || z >= size.z) {
+        return false;
+    }
+    return data[x + size.x * (y + size.y * z)] != 0;
+}
+
+Ref<ArrayMesh> BinaryGreedyMesher::build_mesh(const PackedByteArray &voxels, const Vector3i &size, int lod) {
+    Ref<ArrayMesh> mesh;
+    mesh.instantiate();
+
+    if (voxels.is_empty() || size.x <= 0 || size.y <= 0 || size.z <= 0) {
+        return mesh;
+    }
+
+    const uint8_t *data = voxels.ptr();
+    int dims[3] = {size.x, size.y, size.z};
+
+    std::vector<Vector3> vertices;
+    std::vector<Vector3> normals;
+    std::vector<int> indices;
+
+    int voxel_scale = 1 << lod;
+    Vector3 scale((real_t)voxel_scale, (real_t)voxel_scale, (real_t)voxel_scale);
+
+    for (int d = 0; d < 3; ++d) {
+        int u = (d + 1) % 3;
+        int v = (d + 2) % 3;
+
+        std::vector<int> mask(dims[u] * dims[v]);
+        int x[3] = {0, 0, 0};
+        int q[3] = {0, 0, 0};
+        q[d] = 1;
+
+        for (x[d] = -1; x[d] < dims[d];) {
+            // Build mask
+            int n = 0;
+            for (x[v] = 0; x[v] < dims[v]; ++x[v]) {
+                for (x[u] = 0; x[u] < dims[u]; ++x[u]) {
+                    bool a = (x[d] >= 0) ? voxel_at(data, x[0], x[1], x[2], size) : false;
+                    bool b = (x[d] < dims[d] - 1) ? voxel_at(data, x[0] + q[0], x[1] + q[1], x[2] + q[2], size) : false;
+                    mask[n++] = (a != b) ? (a ? 1 : -1) : 0;
+                }
+            }
+
+            ++x[d];
+            n = 0;
+
+            for (int j = 0; j < dims[v]; ++j) {
+                for (int i = 0; i < dims[u];) {
+                    int c = mask[n];
+                    if (c != 0) {
+                        int w = 1;
+                        while (i + w < dims[u] && mask[n + w] == c) {
+                            ++w;
+                        }
+                        int h = 1;
+                        bool done = false;
+                        while (j + h < dims[v]) {
+                            for (int k = 0; k < w; ++k) {
+                                if (mask[n + k + h * dims[u]] != c) {
+                                    done = true;
+                                    break;
+                                }
+                            }
+                            if (done) {
+                                break;
+                            }
+                            ++h;
+                        }
+
+                        x[u] = i;
+                        x[v] = j;
+
+                        Vector3 du;
+                        du[u] = w;
+                        Vector3 dv;
+                        dv[v] = h;
+                        Vector3 pos((real_t)x[0], (real_t)x[1], (real_t)x[2]);
+                        Vector3 normal;
+                        normal[d] = c > 0 ? 1.0f : -1.0f;
+
+                        int start = vertices.size();
+                        if (c > 0) {
+                            vertices.push_back((pos) * scale);
+                            vertices.push_back((pos + du) * scale);
+                            vertices.push_back((pos + dv) * scale);
+                            vertices.push_back((pos + du + dv) * scale);
+
+                            normals.insert(normals.end(), 4, normal);
+
+                            indices.push_back(start + 0);
+                            indices.push_back(start + 1);
+                            indices.push_back(start + 2);
+                            indices.push_back(start + 1);
+                            indices.push_back(start + 3);
+                            indices.push_back(start + 2);
+                        } else {
+                            Vector3 pos2 = pos + Vector3(q[0], q[1], q[2]);
+                            vertices.push_back((pos2) * scale);
+                            vertices.push_back((pos2 + dv) * scale);
+                            vertices.push_back((pos2 + du) * scale);
+                            vertices.push_back((pos2 + du + dv) * scale);
+
+                            normals.insert(normals.end(), 4, normal);
+
+                            indices.push_back(start + 0);
+                            indices.push_back(start + 1);
+                            indices.push_back(start + 2);
+                            indices.push_back(start + 1);
+                            indices.push_back(start + 3);
+                            indices.push_back(start + 2);
+                        }
+
+                        for (int l = 0; l < h; ++l) {
+                            for (int k = 0; k < w; ++k) {
+                                mask[n + k + l * dims[u]] = 0;
+                            }
+                        }
+
+                        i += w;
+                        n += w;
+                    } else {
+                        ++i;
+                        ++n;
+                    }
+                }
+            }
+        }
+    }
+
+    PackedVector3Array pvertices;
+    pvertices.resize(vertices.size());
+    for (int i = 0; i < vertices.size(); ++i) {
+        pvertices[i] = vertices[i];
+    }
+
+    PackedVector3Array pnormals;
+    pnormals.resize(normals.size());
+    for (int i = 0; i < normals.size(); ++i) {
+        pnormals[i] = normals[i];
+    }
+
+    PackedInt32Array pindices;
+    pindices.resize(indices.size());
+    for (int i = 0; i < indices.size(); ++i) {
+        pindices[i] = indices[i];
+    }
+
+    Array arr;
+    arr.resize(Mesh::ARRAY_MAX);
+    arr[Mesh::ARRAY_VERTEX] = pvertices;
+    arr[Mesh::ARRAY_NORMAL] = pnormals;
+    arr[Mesh::ARRAY_INDEX] = pindices;
+
+    mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arr);
+    return mesh;
+}
+
+void BinaryGreedyMesher::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("build_mesh", "voxels", "size", "lod"), &BinaryGreedyMesher::build_mesh, DEFVAL(0));
+}

--- a/mixed-voxels/extensions/binary_greedy_mesher/src/binary_greedy_mesher.h
+++ b/mixed-voxels/extensions/binary_greedy_mesher/src/binary_greedy_mesher.h
@@ -1,0 +1,22 @@
+#ifndef BINARY_GREEDY_MESHER_H
+#define BINARY_GREEDY_MESHER_H
+
+#include <godot_cpp/classes/array_mesh.hpp>
+#include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/variant/packed_byte_array.hpp>
+#include <godot_cpp/variant/vector3i.hpp>
+
+using namespace godot;
+
+class BinaryGreedyMesher : public RefCounted {
+    GDCLASS(BinaryGreedyMesher, RefCounted);
+
+protected:
+    static void _bind_methods();
+
+public:
+    BinaryGreedyMesher() = default;
+    Ref<ArrayMesh> build_mesh(const PackedByteArray &voxels, const Vector3i &size, int lod = 0);
+};
+
+#endif // BINARY_GREEDY_MESHER_H

--- a/mixed-voxels/extensions/binary_greedy_mesher/src/register_types.cpp
+++ b/mixed-voxels/extensions/binary_greedy_mesher/src/register_types.cpp
@@ -1,0 +1,33 @@
+#include "register_types.h"
+#include "binary_greedy_mesher.h"
+
+#include <godot_cpp/gdextension_interface.h>
+#include <godot_cpp/core/engine.hpp>
+
+using namespace godot;
+
+void initialize_binary_greedy_mesher_module(ModuleInitializationLevel p_level) {
+    if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+        return;
+    }
+    ClassDB::register_class<BinaryGreedyMesher>();
+}
+
+void uninitialize_binary_greedy_mesher_module(ModuleInitializationLevel p_level) {
+    if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+        return;
+    }
+}
+
+extern "C" {
+GDExtensionBool GDE_EXPORT binary_greedy_mesher_library_init(
+        GDExtensionInterfaceGetProcAddress p_get_proc_address,
+        GDExtensionClassLibraryPtr p_library,
+        GDExtensionInitialization *r_initialization) {
+    GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
+    init_obj.register_initializer(initialize_binary_greedy_mesher_module);
+    init_obj.register_terminator(uninitialize_binary_greedy_mesher_module);
+    init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
+    return init_obj.init();
+}
+}

--- a/mixed-voxels/extensions/binary_greedy_mesher/src/register_types.h
+++ b/mixed-voxels/extensions/binary_greedy_mesher/src/register_types.h
@@ -1,0 +1,11 @@
+#ifndef BINARY_GREEDY_MESHER_REGISTER_TYPES_H
+#define BINARY_GREEDY_MESHER_REGISTER_TYPES_H
+
+#include <godot_cpp/core/class_db.hpp>
+
+using namespace godot;
+
+void initialize_binary_greedy_mesher_module(ModuleInitializationLevel p_level);
+void uninitialize_binary_greedy_mesher_module(ModuleInitializationLevel p_level);
+
+#endif // BINARY_GREEDY_MESHER_REGISTER_TYPES_H


### PR DESCRIPTION
## Summary
- Add `BinaryGreedyMesher` GDExtension with greedy meshing for binary voxel data
- Expose `build_mesh` method to convert voxel buffers into optimized triangle meshes
- Provide build script and GDExtension config for integration

## Testing
- `scons` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b186f74e2c8333af6c5324b44404be