### PR TITLE
Add basic 3D player controller and voxel test scene

### DIFF
--- a/mixed-voxels/project.godot
+++ b/mixed-voxels/project.godot
@@ -13,3 +13,13 @@ config_version=5
 config/name="Mixed Voxels"
 config/features=PackedStringArray("4.4", "Forward Plus")
 config/icon="res://icon.svg"
+run/main_scene="res://scenes/voxel_test.tscn"
+
+[input]
+
+move_forward={"deadzone":0.5,"events":[{"type":"key","keycode":87,"physical_keycode":87}]}
+move_backward={"deadzone":0.5,"events":[{"type":"key","keycode":83,"physical_keycode":83}]}
+move_left={"deadzone":0.5,"events":[{"type":"key","keycode":65,"physical_keycode":65}]}
+move_right={"deadzone":0.5,"events":[{"type":"key","keycode":68,"physical_keycode":68}]}
+move_up={"deadzone":0.5,"events":[{"type":"key","keycode":32,"physical_keycode":32}]}
+move_down={"deadzone":0.5,"events":[{"type":"key","keycode":67,"physical_keycode":67}]}

--- a/mixed-voxels/scenes/player.tscn
+++ b/mixed-voxels/scenes/player.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scripts/player.gd" type="Script" id=1]
+
+[node name="Player" type="Node3D"]
+script = ExtResource(1)
+
+[node name="Camera3D" type="Camera3D" parent="."]
+position = Vector3(0, 1.7, 0)

--- a/mixed-voxels/scenes/voxel_test.tscn
+++ b/mixed-voxels/scenes/voxel_test.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource path="res://scripts/lod_terrain.gd" type="Script" id=1]
+[ext_resource path="res://scenes/player.tscn" type="PackedScene" id=2]
+
+[node name="VoxelTest" type="Node3D"]
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+rotation_degrees = Vector3(-45, 0, 0)
+
+[node name="LodTerrain" type="Node3D" parent="."]
+script = ExtResource(1)
+player_path = NodePath("../Player")
+
+[node name="Player" parent="." instance=ExtResource(2)]

--- a/mixed-voxels/scripts/player.gd
+++ b/mixed-voxels/scripts/player.gd
@@ -1,0 +1,40 @@
+extends Node3D
+
+@export var move_speed: float = 10.0
+@export var mouse_sensitivity: float = 0.002
+
+@onready var camera: Camera3D = $Camera3D
+
+var yaw := 0.0
+var pitch := 0.0
+
+func _ready() -> void:
+    Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
+
+func _unhandled_input(event: InputEvent) -> void:
+    if event is InputEventMouseMotion:
+        yaw -= event.relative.x * mouse_sensitivity
+        pitch -= event.relative.y * mouse_sensitivity
+        pitch = clamp(pitch, deg_to_rad(-89.0), deg_to_rad(89.0))
+        rotation.y = yaw
+        camera.rotation.x = pitch
+    elif event.is_action_pressed("ui_cancel"):
+        Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
+
+func _process(delta: float) -> void:
+    var dir := Vector3.ZERO
+    if Input.is_action_pressed("move_forward"):
+        dir -= transform.basis.z
+    if Input.is_action_pressed("move_backward"):
+        dir += transform.basis.z
+    if Input.is_action_pressed("move_left"):
+        dir -= transform.basis.x
+    if Input.is_action_pressed("move_right"):
+        dir += transform.basis.x
+    if Input.is_action_pressed("move_up"):
+        dir += transform.basis.y
+    if Input.is_action_pressed("move_down"):
+        dir -= transform.basis.y
+
+    if dir != Vector3.ZERO:
+        global_translate(dir.normalized() * move_speed * delta)


### PR DESCRIPTION
## Summary
- Implement free-flying 3D player controller with mouse look
- Add player and voxel test scenes wired to existing LOD terrain
- Configure project main scene and input actions for movement

## Testing
- `apt-get update` *(fails: The repository 'http://security.ubuntu.com/ubuntu noble-security InRelease' is not signed)*
- `godot --headless --check-only` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b18d7f8d408333a103ce4edbef2a88