### PR TITLE
Offload terrain mesh building to background C++ worker

### DIFF
--- a/mixed-voxels/extensions/binary_greedy_mesher/src/binary_greedy_mesher.h
+++ b/mixed-voxels/extensions/binary_greedy_mesher/src/binary_greedy_mesher.h
@@ -3,8 +3,15 @@
 
 #include <godot_cpp/classes/array_mesh.hpp>
 #include <godot_cpp/classes/ref.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
 #include <godot_cpp/variant/packed_byte_array.hpp>
 #include <godot_cpp/variant/vector3i.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
 
 using namespace godot;
 
@@ -14,9 +21,36 @@ class BinaryGreedyMesher : public RefCounted {
 protected:
     static void _bind_methods();
 
+    struct Job {
+        PackedByteArray voxels;
+        Vector3i size;
+        int lod;
+        Variant chunk;
+    };
+
+    struct Result {
+        Ref<ArrayMesh> mesh;
+        Variant chunk;
+    };
+
+    std::mutex jobs_mutex;
+    std::condition_variable jobs_cv;
+    std::deque<Job> jobs;
+    std::mutex results_mutex;
+    std::deque<Result> results;
+    std::thread worker;
+    bool stop_worker = false;
+
+    void thread_main();
+
 public:
-    BinaryGreedyMesher() = default;
+    BinaryGreedyMesher();
+    ~BinaryGreedyMesher();
+
     Ref<ArrayMesh> build_mesh(const PackedByteArray &voxels, const Vector3i &size, int lod = 0);
+    void schedule_mesh(const PackedByteArray &voxels, const Vector3i &size, int lod, Variant chunk);
+    Dictionary pop_completed();
+    void stop();
 };
 
 #endif // BINARY_GREEDY_MESHER_H


### PR DESCRIPTION
## Summary
- add asynchronous job queue and worker thread to `BinaryGreedyMesher` gdextension
- process completed mesh builds on the main thread with a frame budget
- update LOD terrain script to use the threaded C++ mesher

## Testing
- `scons` *(fails: command not found)*
- `godot --version` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b19082c32c833388992b58eaeb2d69